### PR TITLE
feat: quota fallback model with silent-failure detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to `pi-finder-subagent` are documented here.
 
 ### Added
 
-- None.
+- Quota fallback: when the primary subagent model fails due to quota exhaustion or rate limits, Finder automatically retries with a fallback model. Two failure modes are handled: exception-based (API throws 429/quota error) and silent failure (model completes with zero tool calls and no output). Fallback model defaults to `anthropic/claude-sonnet-4-6:high` and can be overridden via `PI_FINDER_FALLBACK_MODEL=provider/model:thinking`. Set to empty string to disable.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ export PI_FINDER_MODEL=google-antigravity/gemini-3-flash:low
 - The requested model must exist in `modelRegistry.getAvailable()` (i.e. credentials are configured for that provider/model).
 - In override mode, selection diagnostics report an explicit `reason` including the chosen `provider/model:thinking`.
 
+## Quota fallback
+
+When the primary model fails due to quota exhaustion or rate limits, Finder automatically retries with a fallback model. Two failure modes are handled:
+
+- **Exception-based**: API returns a 429 / quota error that throws — detected via error message patterns.
+- **Silent failure**: Model runs but calls no tools and returns no output — detected by inspecting the completed run.
+
+The fallback model defaults to `anthropic/claude-sonnet-4-6:high` and can be overridden:
+
+```bash
+export PI_FINDER_FALLBACK_MODEL=anthropic/claude-opus-4-6:low
+```
+
+Format is the same as `PI_FINDER_MODEL`: `provider/model:thinking`.
+
+- Set `PI_FINDER_FALLBACK_MODEL=""` to disable fallback entirely.
+- The fallback model must be available in `modelRegistry.getAvailable()`.
+- If primary and fallback resolve to the same model ID, fallback is skipped.
+- Selection diagnostics report `fallback (quota): provider/model:thinking` when fallback is active.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

When the primary subagent model hits quota exhaustion or rate limits, Finder now automatically retries with a configurable fallback model.

## Problem

Two failure modes were observed:
- **Exception-based**: API throws a 429/quota error — straightforward to catch
- **Silent failure**: model completes `status: done` but made **zero tool calls** and returned no output — the pattern seen with weekly quota exhaustion on Codex models (the run looks successful but nothing happened)

## Changes

### `extensions/index.ts`

- Added `isQuotaError(error)`: detects quota/rate-limit exceptions via error message patterns (`rate limit`, `quota`, `429`, `insufficient_quota`, `out of credits`, `billing`)
- Added `selectFinderFallbackModel(modelRegistry, primaryModelId)`: reads `PI_FINDER_FALLBACK_MODEL` env var (defaults to `anthropic/claude-sonnet-4-6:high`), skips fallback if same model as primary
- Added `looksLikeSilentQuotaFailure(run)`: detects silent failure — `status === done`, zero tool calls, no output
- Extracted `runOneAttempt(model, thinkingLevel)`: encapsulates session lifecycle (with cleanup on retry) so both primary and fallback attempts share the same code path
- Retry logic: on exception → check `isQuotaError`; on success → check `looksLikeSilentQuotaFailure`; if either triggers and a fallback is available, switch model vars and re-run

### `README.md`

Added **Quota fallback** section documenting both failure modes, `PI_FINDER_FALLBACK_MODEL` override, and selection diagnostics format.

### `CHANGELOG.md`

Added entry under `[Unreleased]`.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `PI_FINDER_FALLBACK_MODEL` | `anthropic/claude-sonnet-4-6:high` | Fallback model when primary quota exhausted |

Set to empty string (`PI_FINDER_FALLBACK_MODEL=""`) to disable fallback entirely.